### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     ],
     "description": "Converts shapes of classes on videos (e.g. polygon to bitmap) and all corresponding objects",
     "docker_image": "supervisely/data-operations:6.73.564",
-    "instance_version": "6.4.57",
+    "instance_version": "6.15.60",
     "main_script": "src/main.py",
     "gui_template": "src/gui.html",
     "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
         "data operations"
     ],
     "description": "Converts shapes of classes on videos (e.g. polygon to bitmap) and all corresponding objects",
-    "docker_image": "supervisely/data-operations:6.72.161",
+    "docker_image": "supervisely/data-operations:6.73.564",
     "instance_version": "6.4.57",
     "main_script": "src/main.py",
     "gui_template": "src/gui.html",

--- a/config.json
+++ b/config.json
@@ -1,26 +1,26 @@
 {
-    "name": "Convert Video Class Shape",
-    "type": "app",
-    "categories": [
-        "videos",
-        "annotation transformation",
-        "data operations"
+  "name": "Convert Video Class Shape",
+  "type": "app",
+  "categories": [
+    "videos",
+    "annotation transformation",
+    "data operations"
+  ],
+  "description": "Converts shapes of classes on videos (e.g. polygon to bitmap) and all corresponding objects",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "instance_version": "6.15.60",
+  "main_script": "src/main.py",
+  "gui_template": "src/gui.html",
+  "modal_template": "src/modal.html",
+  "task_location": "workspace_tasks",
+  "isolate": true,
+  "icon": "https://i.imgur.com/N2TmbHL.png",
+  "icon_background": "#FFFFFF",
+  "context_menu": {
+    "target": [
+      "videos_project"
     ],
-    "description": "Converts shapes of classes on videos (e.g. polygon to bitmap) and all corresponding objects",
-    "docker_image": "supervisely/data-operations:6.73.564",
-    "instance_version": "6.15.60",
-    "main_script": "src/main.py",
-    "gui_template": "src/gui.html",
-    "modal_template": "src/modal.html",
-    "task_location": "workspace_tasks",
-    "isolate": true,
-    "icon": "https://i.imgur.com/N2TmbHL.png",
-    "icon_background": "#FFFFFF",
-    "context_menu": {
-        "target": [
-            "videos_project"
-        ],
-        "context_category": "Transform"
-    },
-    "poster": "https://user-images.githubusercontent.com/106374579/183414846-10e2d52b-6e85-4f25-bc46-14fe045c5018.png"
+    "context_category": "Transform"
+  },
+  "poster": "https://user-images.githubusercontent.com/106374579/183414846-10e2d52b-6e85-4f25-bc46-14fe045c5018.png"
 }

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "data operations"
   ],
   "description": "Converts shapes of classes on videos (e.g. polygon to bitmap) and all corresponding objects",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.161
+supervisely==6.73.564

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 import globals as g
-import supervisely_lib as sly
-from supervisely_lib.video_annotation.key_id_map import KeyIdMap
-from supervisely_lib.annotation.json_geometries_map import GET_GEOMETRY_FROM_STR
+import supervisely as sly
+from supervisely.video_annotation.key_id_map import KeyIdMap
+from supervisely.annotation.json_geometries_map import GET_GEOMETRY_FROM_STR
 from functools import partial
 
 


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
